### PR TITLE
search: introduce a new hyperscan-backed searchdef type: `HyperscanSearchDef`

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -45,3 +45,11 @@ disable=
  broad-exception-raised,
  unspecified-encoding,
  consider-using-f-string,
+
+[TYPECHECK]
+# List of module names for which member attributes should not be checked
+#
+# hyperscan is on ignore list because pylint is having trouble locating module
+# members for hyperscan and raising invalid "no-member" errors, e.g.;
+# Module 'hyperscan' has no 'Database' member (no-member)
+ignored-modules=hyperscan

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,4 +23,5 @@ dynamic = ["version"]
 dependencies = [
     'importlib-metadata; python_version >= "3.8"',
     'fasteners',
+    'hyperscan >= 0.7.0'
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 fasteners
+hyperscan >= 0.7.0

--- a/searchkit/__init__.py
+++ b/searchkit/__init__.py
@@ -2,5 +2,6 @@ from .search import (   # noqa: F403,F401
     FileSearcher,
     ResultFieldInfo,
     SearchDef,
+    HyperscanSearchDef,
     SequenceSearchDef,
 )

--- a/searchkit/log.py
+++ b/searchkit/log.py
@@ -1,22 +1,26 @@
 #!/usr/bin/python3
 import logging
 
-log = logging.getLogger('searchkit')
-logformat = ("%(asctime)s %(process)d %(levelname)s %(name)s [-] "
-             "%(message)s")
-
-
-def configure_handler():
-    handler = logging.StreamHandler()
-    handler.setFormatter(logging.Formatter(logformat))
-    log.addHandler(handler)
-
-
 def set_log_level(level):
     log.setLevel(level)
     if not log.hasHandlers():
-        configure_handler()
+        configure_handler(log)
 
+def configure_handler(logger_obj):
+    logformat = ("%(asctime)s %(process)d %(levelname)s %(name)s [-] "
+             "%(message)s")
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter(logformat))
+    logger_obj.addHandler(handler)
+
+def initialize_new_logger(name):
+    new_logger = logging.getLogger(name)
+    if not new_logger.hasHandlers():
+        new_logger.setLevel(logging.INFO)
+        configure_handler(logger_obj=new_logger)
+    return new_logger
+
+log = initialize_new_logger("searchkit")
 
 if log.level and not log.hasHandlers():
-    configure_handler()
+    configure_handler(log)


### PR DESCRIPTION
Searchkit currently uses python's re which is not known for its' "blow your socks off" pattern scanning performance, hence there is an opportunity for optimization by simply swapping the regex engine.

Hyperscan is a highly optimized, performant regex engine that is typically used high throughput network packet inspection systems (e.g. DPI, IDS/IPS systems) for pattern recognition. The work that searchkit does is aligned with hyperscan's properties so it would be beneficial for searchkit to allow downstream users to leverage hyperscan, especially for searching large files.

This patch introduces a hyperscan-backed SearchDef type which can be used as a drop-in replacement for the existing SearchDef type. The patch also adds hyperscan as a dependency and moves searchkit tests to a base class so the tests can be used for testing both SearchDef and HyperscanSearchDef at the same time.