### PR TITLE
[unittest] Define _addDuration method to suppress 3.12 warnings

### DIFF
--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -43,3 +43,10 @@ class BaseTestCase(unittest.TestCase):
             set_log_level(logging.DEBUG)
         else:
             set_log_level(logging.INFO)
+
+    def _addDuration(self, *args, **kwargs):  # For Python >= 3.12
+        """ Python 3.12 needs subclasses of unittest.TestCase to implement
+        this in order to record times and execute any cleanup actions once
+        a test completes regardless of success. Otherwise it emits a warning.
+        This generic implementation helps suppress it and possibly others in
+        the future. """


### PR DESCRIPTION
Change:
python/cpython@d88087e

This essentially suppresses the warnings:
RuntimeWarning: TestResult has no addDuration method\n  warnings.warn("TestResult has no addDuration method")

original-commit: https://github.com/canonical/hotsos/commit/7ebf6ef8e842bf6133effe529be8734a03ace084