### PR TITLE
tox.ini/stestr: remove --serial to enable test parallelization

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ passenv =
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test-requirements.txt
-commands = stestr run --serial --test-path {[testenv]unit_tests} {posargs}
+commands = stestr run --random --slowest --test-path {[testenv]unit_tests} {posargs}
 
 [testenv:pep8]
 allowlist_externals = flake8


### PR DESCRIPTION
also add --random and --slowest