### PR TITLE
unit-tests: add assertLogs(...) to suppress/verify log output

### DIFF
--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -925,13 +925,17 @@ class TestSearchKit(TestSearchKitBase):
     def test_search_unicode_decode_w_error(self):
         f = FileSearcher()
         with tempfile.TemporaryDirectory() as dtmp:
-            fpath = os.path.join(dtmp, 'f1')
-            with open(fpath, 'wb') as fd:
-                fd.write(b'\xe2')
+            with self.assertLogs(logger="searchkit", level="ERROR") as log:
+                fpath = os.path.join(dtmp, 'f1')
+                with open(fpath, 'wb') as fd:
+                    fd.write(b'\xe2')
 
-            f.add(SearchDef(r'(.+)', tag='simple'), fpath)
-            with self.assertRaises(UnicodeDecodeError):
-                f.run()
+                f.add(SearchDef(r'(.+)', tag='simple'), fpath)
+                with self.assertRaises(UnicodeDecodeError):
+                    f.run()
+                self.assertEqual(len(log.output), 1)
+                self.assertIn("UnicodeDecodeError: 'utf-8' codec can't decode "
+                              "byte 0xe2 in position", log.output[0])
 
     def test_search_unicode_decode_no_error(self):
         f = FileSearcher(decode_errors='backslashreplace')

--- a/tests/unit/test_search_constraints.py
+++ b/tests/unit/test_search_constraints.py
@@ -198,9 +198,13 @@ class TestSearchConstraints(TestSearchKitBase):
         with open(_file, 'w') as fd:
             fd.write('somejunk\n' * 501 + LOGS_W_TS)
 
-        with open(_file, 'rb') as fd:
-            offset = c.apply_to_file(fd)
-            self.assertEqual(offset, 0)
+        with self.assertLogs(logger="searchkit", level="WARNING") as log:
+            with open(_file, 'rb') as fd:
+                offset = c.apply_to_file(fd)
+                self.assertEqual(offset, 0)
+            self.assertEqual(len(log.output), 1)
+            self.assertIn("failed to find a line containing a date: "
+                          "date search failed at offset", log.output[0])
 
         stats = {'line': {'fail': 0, 'pass': 0}, 'lines_searched': 0}
         self.assertEqual(c.stats(), stats)


### PR DESCRIPTION
unit tests trigger log printing which can be confusing at first glance since there are errors and warnings being printed. this patch adds self.assertLogs(...) to reflect that we're expecting the code to trigger warning and error messages and also verify their content.